### PR TITLE
Hidden fields

### DIFF
--- a/API.md
+++ b/API.md
@@ -355,6 +355,7 @@ All components are defined as an object with keys:
 Form components capture information from a user and are rendered inside an HTML form.
 The available `type` values for these are:
   - [TextField](#textfield-component)
+  - [HiddenField](#hiddenfield-component)
   - [NumberField](#numberfield-component)
   - [NamesField](#namesfield-component)
   - [TelephoneNumberField](#telephonenumberfield-component)
@@ -621,9 +622,8 @@ Simple text field.
     - `trim` - boolean - whether to force whitespace trimming from the start and end of the text.
 
 ## `HiddenField` component
-Extends the text field component and behaves largely in the same way, but is fed a value.
-The input field type is automatically set to 'hidden', and the whole macro is wrapped with `display: none;` to prevent the field name and/or hint text from appearing in the UI.
-  - `value` - any string - the value given to the <input> element
+Renders an `<input>` with `type="hidden'`
+  - `value` - string - the value given to the <input> element
 
 ## `WarningText` component
 Text using the Warning Text component.

--- a/API.md
+++ b/API.md
@@ -620,6 +620,11 @@ Simple text field.
     - `max` - number - the maximum length of text to allow.
     - `trim` - boolean - whether to force whitespace trimming from the start and end of the text.
 
+## `HiddenField` component
+Extends the text field component and behaves largely in the same way, but is fed a value.
+The input field type is automatically set to 'hidden', and the whole macro is wrapped with `display: none;` to prevent the field name and/or hint text from appearing in the UI.
+  - `value` - any string - the value given to the <input> element
+
 ## `WarningText` component
 Text using the Warning Text component.
   - `text` - string of text to display.

--- a/components/hiddenfield.js
+++ b/components/hiddenfield.js
@@ -1,7 +1,7 @@
 const joi = require('@hapi/joi')
-const TextField = require('./textfield')
+const { FormComponent } = require('.')
 
-class HiddenField extends TextField {
+class HiddenField extends FormComponent {
   constructor(definition) {
     super(definition)
     let schema = joi.any()
@@ -17,7 +17,6 @@ class HiddenField extends TextField {
   getViewModel(config, formData, errors) {
     const { value } = this
     const viewModel = super.getViewModel(config, formData, errors)
-    viewModel.type = 'hidden'
     viewModel.value = this.value
     return viewModel
   }

--- a/components/hiddenfield.js
+++ b/components/hiddenfield.js
@@ -1,0 +1,26 @@
+const joi = require('@hapi/joi')
+const TextField = require('./textfield')
+
+class HiddenField extends TextField {
+  constructor(definition) {
+    super(definition)
+    let schema = joi.any()
+    this.formSchema = schema
+  }
+
+  getFormSchemaKeys(config) {
+    const { name } = this
+    let { formSchema } = this
+    return { [name]: formSchema }
+  }
+
+  getViewModel(config, formData, errors) {
+    const { value } = this
+    const viewModel = super.getViewModel(config, formData, errors)
+    viewModel.type = 'hidden'
+    viewModel.value = this.value
+    return viewModel
+  }
+}
+
+module.exports = HiddenField

--- a/hapi-govuk-question-page/components/hiddenfield.njk
+++ b/hapi-govuk-question-page/components/hiddenfield.njk
@@ -1,5 +1,3 @@
-{% from "./textfield.njk" import TextField %}
-
 {% macro HiddenField(component) %}
-  <span style="display:none;">{{ TextField(component) }}</span>
+  <input name="{{ component.model.name }}" type="hidden" value="{{ component.model.value }}" />
 {% endmacro %}

--- a/hapi-govuk-question-page/components/hiddenfield.njk
+++ b/hapi-govuk-question-page/components/hiddenfield.njk
@@ -1,0 +1,5 @@
+{% from "./textfield.njk" import TextField %}
+
+{% macro HiddenField(component) %}
+  <span style="display:none;">{{ TextField(component) }}</span>
+{% endmacro %}

--- a/page.js
+++ b/page.js
@@ -18,7 +18,8 @@ const componentTypesList = [
   'DynamicHtml',
   'InsetText',
   'Details',
-  'WarningText'
+  'WarningText',
+  'HiddenField'
 ]
 const componentTypes = componentTypesList.reduce((acc, name) => {
   acc[name] = require(`./components/${name.toLowerCase()}`)
@@ -45,13 +46,12 @@ const mapErrorsForDisplay = (joiError) => {
 }
 
 class Page {
-  constructor (pageDef, pageTemplateName) {
+  constructor(pageDef, pageTemplateName) {
     const { title, caption, hasNext = true } = pageDef
     this.title = title
     this.caption = caption
     this.hasNext = hasNext
     this.pageTemplateName = pageTemplateName
-
     const components = pageDef.components.map(def => new componentTypes[def.type](def))
     const formComponents = components.filter(component => component.isFormComponent)
 
@@ -62,14 +62,13 @@ class Page {
     this.hasSingleFormComponentFirst = formComponents.length === 1 && formComponents[0] === components[0]
   }
 
-  getViewModel (config = {}, formData, errors) {
+  getViewModel(config = {}, formData, errors) {
     const { $PAGE$: pageConfig = {} } = config
     let { title: pageTitle = this.title, caption: pageCaption = this.caption } = pageConfig
     let showTitle = Boolean(pageTitle)
 
     const templateName = this.pageTemplateName
     const useForm = this.hasFormComponents || this.hasNext
-
     const components = this.components.map(component => ({
       type: component.type,
       isFormComponent: component.isFormComponent,
@@ -96,21 +95,21 @@ class Page {
     return { templateName, pageTitle, pageCaption, showTitle, useForm, components, errors }
   }
 
-  getFormDataFromState (state, config) {
+  getFormDataFromState(state, config) {
     return this.formComponents.reduce((acc, formComponent) => {
       Object.assign(acc, formComponent.getFormDataFromState(state, config))
       return acc
     }, {})
   }
 
-  getStateFromValidForm (validatedFormData, config) {
+  getStateFromValidForm(validatedFormData, config) {
     return this.formComponents.reduce((acc, formComponent) => {
       Object.assign(acc, formComponent.getStateFromValidForm(validatedFormData, config))
       return acc
     }, {})
   }
 
-  validateForm (payload, config) {
+  validateForm(payload, config) {
     const formSchemaKeys = this.formComponents.reduce((acc, formComponent) => {
       Object.assign(acc, formComponent.getFormSchemaKeys(config))
       return acc

--- a/test-harness/test-harness-page.js
+++ b/test-harness/test-harness-page.js
@@ -29,6 +29,10 @@ module.exports = {
     },
     hint: 'Help text'
   }, {
+    type: 'HiddenField',
+    name: 'hiddenField',
+    value: 3050
+  }, {
     type: 'MultilineTextField',
     name: 'multilineTextField',
     title: 'Multiline text field',

--- a/test/components/hiddenfield.test.js
+++ b/test/components/hiddenfield.test.js
@@ -17,11 +17,6 @@ const formData = {
 
 lab.experiment('HiddenField', () => {
   lab.experiment('getViewModel', () => {
-    lab.test('is hidden type', () => {
-      const hiddenField = new HiddenField(standardDefinition)
-      const viewModel = hiddenField.getViewModel({}, formData)
-      expect(viewModel.type).to.equal('hidden')
-    })
     lab.test('is given the defined value', () => {
       const hiddenField = new HiddenField(standardDefinition)
       const viewModel = hiddenField.getViewModel({}, formData)

--- a/test/components/hiddenfield.test.js
+++ b/test/components/hiddenfield.test.js
@@ -1,0 +1,38 @@
+const Code = require('@hapi/code')
+const Lab = require('@hapi/lab')
+
+const HiddenField = require('../../components/hiddenfield')
+
+const { expect } = Code
+const lab = exports.lab = Lab.script()
+
+const componentName = 'testHiddenField'
+const standardDefinition = {
+  name: componentName,
+  value: '5050'
+}
+const formData = {
+  [componentName]: null
+}
+
+lab.experiment('HiddenField', () => {
+  lab.experiment('getViewModel', () => {
+    lab.test('is hidden type', () => {
+      const hiddenField = new HiddenField(standardDefinition)
+      const viewModel = hiddenField.getViewModel({}, formData)
+      expect(viewModel.type).to.equal('hidden')
+    })
+    lab.test('is given the defined value', () => {
+      const hiddenField = new HiddenField(standardDefinition)
+      const viewModel = hiddenField.getViewModel({}, formData)
+      expect(viewModel.value).to.equal('5050')
+    })
+  })
+  lab.experiment('getFormSchemaKeys', () => {
+    lab.test('returns schema for defined name', () => {
+      const hiddenField = new HiddenField(standardDefinition)
+      const formSchemaKeys = hiddenField.getFormSchemaKeys()
+      expect(formSchemaKeys[componentName]).to.exist()
+    })
+  })
+})


### PR DESCRIPTION
Introduces the 'hidden' component. Useful for passing CSRF tokens and other hidden/known values.

Usage:

```
components: [{
    type: 'HiddenField',
    name: 'alpha',
    value: 'beta'
}]
```

which renders something along the lines of:
```
<input type='hidden' name='alpha' value='beta' />
```